### PR TITLE
Explizites Auswählen der Repository-Typen für das Backup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,24 +6,25 @@ plugins {
 }
 
 apply plugin: 'java'
+apply plugin: 'eclipse'
 
 repositories {
     jcenter()
 }
 
 group = 'de.set.tools'
-version = '1.0.0'
+version = '1.0.1'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
     compile 'com.google.guava:guava:22.0'
-    compile 'org.jfrog.artifactory.client:artifactory-java-client-services:2.6.0'
-    compile 'org.springframework.boot:spring-boot-starter'
+    compile 'org.jfrog.artifactory.client:artifactory-java-client-services:2.8.0'
+    compile 'org.springframework.boot:spring-boot-starter:1.5.10.RELEASE'
     compile 'com.upplication:s3fs:2.2.1'
 
-    compileOnly 'org.springframework.boot:spring-boot-configuration-processor'
+    compileOnly 'org.springframework.boot:spring-boot-configuration-processor:1.5.10.RELEASE'
 
     testCompile 'junit:junit'
 }


### PR DESCRIPTION
Das Backup-Tool bricht mit einer RuntimeException ab, wenn man im Artifactory ein Distribution-Repository anlegt:

`Caused by: java.lang.RuntimeException: java.lang.RuntimeException: com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl, problem: No enum constant org.jfrog.artifactory.client.model.impl.RepositoryTypeImpl.DISTRIBUTION`